### PR TITLE
Enhance news management by introducing organization-based visibility …

### DIFF
--- a/src/components/herramientas/noticias/news-admin-list.tsx
+++ b/src/components/herramientas/noticias/news-admin-list.tsx
@@ -3,7 +3,7 @@ import { useQuery, useMutation } from "@apollo/client";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faSearch, faTrash, faPencil } from "@fortawesome/free-solid-svg-icons";
 import Image from "next/image";
-import { Query, Mutation, NewsType, NewsUploadedBy, NewsVisibility } from "@/lib/sektor-api/__generated__/types";
+import { Query, Mutation, NewsType, NewsUploadedBy, NewsVisibility, OrganizationTypes } from "@/lib/sektor-api/__generated__/types";
 import { ALL_NEWS_QUERY, HOME_NEWS_QUERY } from "@/lib/sektor-api/queries";
 import { DELETE_NEWS, UPDATE_NEWS } from "@/lib/sektor-api/mutations";
 import TextInput from "@/components/ui/text-input";
@@ -77,6 +77,10 @@ const NewsAdminList: React.FC<NewsAdminListProps> = ({ onEdit, onCreate }) => {
 
     const handleAuthorize = async (news: NewsType) => {
         try {
+            const organizationTypes =
+                (news.allowedOrganizationTypes as OrganizationTypes[]) || [];
+            const hasOrganizationTypes = organizationTypes.length > 0;
+
             await updateNews({
                 variables: {
                     id: news.id,
@@ -85,9 +89,13 @@ const NewsAdminList: React.FC<NewsAdminListProps> = ({ onEdit, onCreate }) => {
                         description: news.description,
                         type: news.type,
                         videoUrl: news.videoUrl || undefined,
-                        allowedRoles: (news.allowedRoles as any) || undefined,
+                        allowedOrganizationTypes: hasOrganizationTypes
+                            ? organizationTypes
+                            : undefined,
                         pendingApproval: false,
-                        visibility: NewsVisibility.Public,
+                        visibility: hasOrganizationTypes
+                            ? NewsVisibility.RoleBased
+                            : NewsVisibility.Public,
                     },
                 },
                 refetchQueries: [{ query: HOME_NEWS_QUERY }, { query: ALL_NEWS_QUERY }],

--- a/src/components/herramientas/noticias/role-selector.tsx
+++ b/src/components/herramientas/noticias/role-selector.tsx
@@ -1,36 +1,36 @@
 import React from "react";
-import { UserGroups } from "@/lib/sektor-api/__generated__/types";
+import { OrganizationTypes } from "@/lib/sektor-api/__generated__/types";
 import { cn } from "@/utils/class-name";
 
 interface RoleSelectorProps {
-  selectedRoles: UserGroups[];
-  onChange: (roles: UserGroups[]) => void;
+  selectedRoles: OrganizationTypes[];
+  onChange: (roles: OrganizationTypes[]) => void;
   disabled?: boolean;
 }
 
 const roleOptions = [
   {
-    value: UserGroups.Member,
+    value: OrganizationTypes.InsuranceBroker,
     label: "Corredor de seguros",
     icon: "/images/entities-icons/corredor-de-seguros.svg",
   },
   {
-    value: UserGroups.Member,
+    value: OrganizationTypes.ExclusiveAgent,
     label: "Agente exclusivo",
     icon: "/images/entities-icons/agente-exclusivo.svg",
   },
   {
-    value: UserGroups.Member,
+    value: OrganizationTypes.BrokerageSociety,
     label: "Sociedad de corretaje",
     icon: "/images/entities-icons/sociedad-de-corretaje.svg",
   },
   {
-    value: UserGroups.Member,
+    value: OrganizationTypes.InsuranceCompany,
     label: "Compañía de seguros",
     icon: "/images/entities-icons/compania-de-seguros.svg",
   },
   {
-    value: UserGroups.Member,
+    value: OrganizationTypes.Supplier,
     label: "Proveedores",
     icon: "/images/entities-icons/proovedores.svg",
   },
@@ -41,9 +41,9 @@ const RoleSelector: React.FC<RoleSelectorProps> = ({
   onChange,
   disabled = false,
 }) => {
-  const toggleRole = (role: UserGroups) => {
+  const toggleRole = (role: OrganizationTypes) => {
     if (disabled) return;
-    
+
     if (selectedRoles.includes(role)) {
       onChange(selectedRoles.filter((r) => r !== role));
     } else {
@@ -53,11 +53,11 @@ const RoleSelector: React.FC<RoleSelectorProps> = ({
 
   return (
     <div className="flex flex-wrap gap-4 sm:gap-6">
-      {roleOptions.map((option, index) => {
+      {roleOptions.map((option) => {
         const isSelected = selectedRoles.includes(option.value);
         return (
           <button
-            key={`${option.value}-${index}`}
+            key={option.value}
             type="button"
             onClick={() => toggleRole(option.value)}
             disabled={disabled}
@@ -79,7 +79,7 @@ const RoleSelector: React.FC<RoleSelectorProps> = ({
                 src={option.icon}
                 alt={option.label}
                 className="w-full h-full object-contain"
-            />
+              />
             </div>
             <span
               className={cn(

--- a/src/lib/sektor-api/__generated__/graphql.ts
+++ b/src/lib/sektor-api/__generated__/graphql.ts
@@ -19,6 +19,219 @@ export type Scalars = {
   File: { input: any; output: any; }
 };
 
+export type AcademyAttendanceQr = {
+  __typename?: 'AcademyAttendanceQr';
+  courseId: Scalars['String']['output'];
+  qrPayload: Scalars['String']['output'];
+  studentId: Scalars['String']['output'];
+};
+
+export type AcademyCalendarItem = {
+  __typename?: 'AcademyCalendarItem';
+  courseId: Scalars['String']['output'];
+  imageUrl?: Maybe<Scalars['String']['output']>;
+  location?: Maybe<Scalars['String']['output']>;
+  modality: AcademyCourseModality;
+  requiresQr: Scalars['Boolean']['output'];
+  scheduledAt: Scalars['DateTime']['output'];
+  title: Scalars['String']['output'];
+};
+
+export type AcademyCourse = {
+  __typename?: 'AcademyCourse';
+  description: Scalars['String']['output'];
+  finalQuizQuestions?: Maybe<Array<AcademyQuizQuestion>>;
+  id: Scalars['String']['output'];
+  imageUrl?: Maybe<Scalars['String']['output']>;
+  level?: Maybe<AcademyCourseLevel>;
+  location?: Maybe<Scalars['String']['output']>;
+  modality?: Maybe<AcademyCourseModality>;
+  modules?: Maybe<Array<AcademyCourseModule>>;
+  priceUsd: Scalars['Float']['output'];
+  scheduledAt?: Maybe<Scalars['DateTime']['output']>;
+  status: AcademyCourseStatus;
+  streamingUrl?: Maybe<Scalars['String']['output']>;
+  title: Scalars['String']['output'];
+};
+
+export type AcademyCourseAsset = {
+  __typename?: 'AcademyCourseAsset';
+  fileUrl: Scalars['String']['output'];
+  id: Scalars['String']['output'];
+  status: AcademyCourseAssetStatus;
+  type: AcademyCourseAssetType;
+};
+
+export enum AcademyCourseAssetStatus {
+  Pending = 'Pending',
+  Uploaded = 'Uploaded'
+}
+
+export enum AcademyCourseAssetType {
+  CourseAttachment = 'CourseAttachment',
+  CourseCover = 'CourseCover',
+  CourseVideo = 'CourseVideo'
+}
+
+export type AcademyCourseAssetUpload = {
+  __typename?: 'AcademyCourseAssetUpload';
+  assetId: Scalars['String']['output'];
+  expiresAt: Scalars['DateTime']['output'];
+  fileUrl: Scalars['String']['output'];
+  signedUrl: Scalars['String']['output'];
+  status: AcademyCourseAssetStatus;
+};
+
+export enum AcademyCourseLevel {
+  Advanced = 'Advanced',
+  Basic = 'Basic',
+  Intermediate = 'Intermediate'
+}
+
+export type AcademyCourseListItem = {
+  __typename?: 'AcademyCourseListItem';
+  enrolledCount: Scalars['Int']['output'];
+  id: Scalars['String']['output'];
+  modality?: Maybe<AcademyCourseModality>;
+  priceUsd: Scalars['Float']['output'];
+  title: Scalars['String']['output'];
+};
+
+export enum AcademyCourseModality {
+  LiveStreaming = 'LiveStreaming',
+  Online = 'Online',
+  Presential = 'Presential'
+}
+
+export type AcademyCourseModule = {
+  __typename?: 'AcademyCourseModule';
+  attachmentUrls?: Maybe<Array<Scalars['String']['output']>>;
+  content?: Maybe<Scalars['String']['output']>;
+  durationSeconds?: Maybe<Scalars['Int']['output']>;
+  quizQuestions?: Maybe<Array<AcademyQuizQuestion>>;
+  title?: Maybe<Scalars['String']['output']>;
+  type: AcademyCourseModuleType;
+  videoUrl?: Maybe<Scalars['String']['output']>;
+};
+
+export type AcademyCourseModuleInput = {
+  attachmentUrls?: InputMaybe<Array<Scalars['String']['input']>>;
+  content?: InputMaybe<Scalars['String']['input']>;
+  durationSeconds?: InputMaybe<Scalars['Int']['input']>;
+  quizQuestions?: InputMaybe<Array<AcademyQuizQuestionInput>>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  type: AcademyCourseModuleType;
+  videoUrl?: InputMaybe<Scalars['String']['input']>;
+};
+
+export enum AcademyCourseModuleType {
+  Quiz = 'Quiz',
+  Text = 'Text',
+  Video = 'Video'
+}
+
+export enum AcademyCourseStatus {
+  Archived = 'Archived',
+  Draft = 'Draft',
+  Published = 'Published'
+}
+
+export type AcademyDashboard = {
+  __typename?: 'AcademyDashboard';
+  approvalRate: Scalars['Float']['output'];
+  publishedCoursesCount: Scalars['Int']['output'];
+  revenueCurrentMonthUsd: Scalars['Float']['output'];
+  revenuePreviousMonthUsd: Scalars['Float']['output'];
+  revenueTotalUsd: Scalars['Float']['output'];
+  topCourses: Array<AcademyDashboardTopCourse>;
+  uniqueStudentsCurrentMonth: Scalars['Int']['output'];
+  uniqueStudentsPreviousMonth: Scalars['Int']['output'];
+  uniqueStudentsTotal: Scalars['Int']['output'];
+};
+
+export type AcademyDashboardTopCourse = {
+  __typename?: 'AcademyDashboardTopCourse';
+  courseId: Scalars['String']['output'];
+  imageUrl?: Maybe<Scalars['String']['output']>;
+  revenueUsd: Scalars['Float']['output'];
+  studentCount: Scalars['Int']['output'];
+  title: Scalars['String']['output'];
+};
+
+export enum AcademyEnrollmentStatus {
+  Active = 'Active',
+  Approved = 'Approved',
+  Completed = 'Completed',
+  Dropped = 'Dropped'
+}
+
+export type AcademyQuizQuestion = {
+  __typename?: 'AcademyQuizQuestion';
+  correctBooleanAnswer?: Maybe<Scalars['Boolean']['output']>;
+  correctOption?: Maybe<Scalars['String']['output']>;
+  options?: Maybe<Array<Scalars['String']['output']>>;
+  title: Scalars['String']['output'];
+  type: AcademyQuizQuestionType;
+};
+
+export type AcademyQuizQuestionInput = {
+  correctBooleanAnswer?: InputMaybe<Scalars['Boolean']['input']>;
+  correctOption?: InputMaybe<Scalars['String']['input']>;
+  options?: InputMaybe<Array<Scalars['String']['input']>>;
+  title: Scalars['String']['input'];
+  type: AcademyQuizQuestionType;
+};
+
+export enum AcademyQuizQuestionType {
+  MultipleChoice = 'MultipleChoice',
+  TrueFalse = 'TrueFalse'
+}
+
+export type AcademyStudentCertificate = {
+  __typename?: 'AcademyStudentCertificate';
+  certificateCode?: Maybe<Scalars['String']['output']>;
+  certificateId?: Maybe<Scalars['String']['output']>;
+  courseId: Scalars['String']['output'];
+  courseTitle: Scalars['String']['output'];
+  downloadUrl?: Maybe<Scalars['String']['output']>;
+  score?: Maybe<Scalars['Float']['output']>;
+  shareUrl?: Maybe<Scalars['String']['output']>;
+  studentName: Scalars['String']['output'];
+  verified: Scalars['Boolean']['output'];
+};
+
+export type AcademyStudentCompletedCourse = {
+  __typename?: 'AcademyStudentCompletedCourse';
+  courseId: Scalars['String']['output'];
+  score?: Maybe<Scalars['Float']['output']>;
+  status: AcademyEnrollmentStatus;
+  title: Scalars['String']['output'];
+};
+
+export type AcademyStudentDetail = {
+  __typename?: 'AcademyStudentDetail';
+  approvedCoursesCount: Scalars['Int']['output'];
+  approvedCoursesRatio: Scalars['Float']['output'];
+  averageScore?: Maybe<Scalars['Float']['output']>;
+  certificates: Array<AcademyStudentCertificate>;
+  completedCourses: Array<AcademyStudentCompletedCourse>;
+  email: Scalars['String']['output'];
+  enrolledCoursesCount: Scalars['Int']['output'];
+  firstEnrolledAt?: Maybe<Scalars['DateTime']['output']>;
+  id: Scalars['String']['output'];
+  initials: Scalars['String']['output'];
+  name: Scalars['String']['output'];
+  studentSinceYear?: Maybe<Scalars['Int']['output']>;
+};
+
+export type AcademyStudentSummary = {
+  __typename?: 'AcademyStudentSummary';
+  approvedCoursesCount: Scalars['Int']['output'];
+  id: Scalars['String']['output'];
+  initials: Scalars['String']['output'];
+  name: Scalars['String']['output'];
+};
+
 export type AddressInputType = {
   cityId: Scalars['Int']['input'];
   countryId: Scalars['Int']['input'];
@@ -44,6 +257,7 @@ export type AdminType = {
   group?: Maybe<UserGroups>;
   id: Scalars['ID']['output'];
   name: Scalars['String']['output'];
+  subscription?: Maybe<SubscriptionDetailsType>;
   subscriptionPlan?: Maybe<SubscriptionPlan>;
   verifiedAt?: Maybe<Scalars['DateTime']['output']>;
 };
@@ -283,6 +497,10 @@ export enum ClinicOrder {
   Current = 'Current'
 }
 
+export type ConfirmAcademyCourseAssetUploadInput = {
+  assetId: Scalars['String']['input'];
+};
+
 export type ConfirmImmediateDebitInputType = {
   holderName: Scalars['String']['input'];
   otp: Scalars['String']['input'];
@@ -313,6 +531,20 @@ export type CountryType = {
   id: Scalars['Int']['output'];
   name: Scalars['String']['output'];
   states: Array<StateType>;
+};
+
+export type CreateAcademyCourseInput = {
+  description: Scalars['String']['input'];
+  finalQuizQuestions?: InputMaybe<Array<AcademyQuizQuestionInput>>;
+  imageUrl?: InputMaybe<Scalars['String']['input']>;
+  level?: InputMaybe<AcademyCourseLevel>;
+  location?: InputMaybe<Scalars['String']['input']>;
+  modality: AcademyCourseModality;
+  modules?: InputMaybe<Array<AcademyCourseModuleInput>>;
+  priceUsd: Scalars['Float']['input'];
+  scheduledAt?: InputMaybe<Scalars['DateTime']['input']>;
+  streamingUrl?: InputMaybe<Scalars['String']['input']>;
+  title: Scalars['String']['input'];
 };
 
 export type CreateCalendarEventInput = {
@@ -364,6 +596,7 @@ export type CustomerType = {
   id: Scalars['ID']['output'];
   name: Scalars['String']['output'];
   sex: Sexes;
+  subscription?: Maybe<SubscriptionDetailsType>;
   subscriptionPlan?: Maybe<SubscriptionPlan>;
   verifiedAt?: Maybe<Scalars['DateTime']['output']>;
 };
@@ -511,6 +744,11 @@ export type FiscalAddressType = {
   reference?: Maybe<Scalars['String']['output']>;
   state: StateType;
   street: Scalars['String']['output'];
+};
+
+export type GenerateAcademyAttendanceQrInput = {
+  courseId: Scalars['String']['input'];
+  studentId: Scalars['String']['input'];
 };
 
 export type HealthQuoteInputType = {
@@ -792,10 +1030,12 @@ export type Mutation = {
   changeOrganizationFeature: PublicOrganizationType;
   changeOrganizationPlan: OrganizationType;
   changeOrganizationVisibility: OrganizationType;
+  confirmAcademyCourseAssetUpload: AcademyCourseAsset;
   /** Step 2: Confirm immediate debit with OTP code. */
   confirmImmediateDebit: InitiatePaymentResultType;
   /** Confirm Pago Móvil after R4 notification evidence exists. */
   confirmMobilePayment: ConfirmMobilePaymentResultType;
+  createAcademyCourse: AcademyCourse;
   createCalendarEvent: CalendarEventType;
   createModule: ModuleType;
   createNews: NewsType;
@@ -808,6 +1048,7 @@ export type Mutation = {
   deleteOrganization: Scalars['Boolean']['output'];
   deleteSurvey: Scalars['Boolean']['output'];
   deleteTracking: Scalars['Boolean']['output'];
+  generateAcademyAttendanceQr: AcademyAttendanceQr;
   getModuleUploadUrl: UploadFileSignedUrlResponse;
   /** Process direct debit payment with optional auto-renewal. */
   initiateDirectDebit: InitiatePaymentResultType;
@@ -823,8 +1064,10 @@ export type Mutation = {
   registerAsExclusiveAgent: RegisterAsOrganizationResponseType;
   registerAsInsuranceBroker: RegisterAsOrganizationResponseType;
   registerAsInsuranceCompany: RegisterAsOrganizationResponseType;
+  registerAsOther: RegisterAsOrganizationResponseType;
   registerAsSupplier: RegisterAsOrganizationResponseType;
   registerDevice: Scalars['Boolean']['output'];
+  requestAcademyCourseAssetUpload: AcademyCourseAssetUpload;
   requestAutoQuote: AutoQuoteType;
   requestHealthQuote: HealthQuoteType;
   requestOtherQuote: OtherQuoteType;
@@ -839,6 +1082,7 @@ export type Mutation = {
   submitNews: NewsType;
   submitSurveyResponse: SurveyResponseType;
   unregisterDevice: Scalars['Boolean']['output'];
+  updateAcademyCourse: AcademyCourse;
   updateBrokerageSociety: BrokerageSocietyType;
   updateCalendarEvent: CalendarEventType;
   updateCustomer: CustomerType;
@@ -862,6 +1106,7 @@ export type Mutation = {
   updateTracking?: Maybe<TrackingType>;
   uploadOfficesTemplate: Array<UploadFileTemplateResult>;
   uploadOrganizationTemplate: Array<UploadFileTemplateResult>;
+  validateAcademyQr: ValidateAcademyQrResult;
   /** Validate an Apple In-App Purchase transaction from StoreKit 2 */
   validateApplePurchase: ApplePurchaseResultType;
 };
@@ -920,6 +1165,11 @@ export type MutationChangeOrganizationVisibilityArgs = {
 };
 
 
+export type MutationConfirmAcademyCourseAssetUploadArgs = {
+  input: ConfirmAcademyCourseAssetUploadInput;
+};
+
+
 export type MutationConfirmImmediateDebitArgs = {
   input: ConfirmImmediateDebitInputType;
 };
@@ -927,6 +1177,12 @@ export type MutationConfirmImmediateDebitArgs = {
 
 export type MutationConfirmMobilePaymentArgs = {
   input: ConfirmMobilePaymentInputType;
+};
+
+
+export type MutationCreateAcademyCourseArgs = {
+  coverPhoto?: InputMaybe<Scalars['File']['input']>;
+  input: CreateAcademyCourseInput;
 };
 
 
@@ -989,6 +1245,11 @@ export type MutationDeleteSurveyArgs = {
 
 export type MutationDeleteTrackingArgs = {
   id: Scalars['String']['input'];
+};
+
+
+export type MutationGenerateAcademyAttendanceQrArgs = {
+  input: GenerateAcademyAttendanceQrInput;
 };
 
 
@@ -1055,6 +1316,11 @@ export type MutationRegisterAsInsuranceCompanyArgs = {
 };
 
 
+export type MutationRegisterAsOtherArgs = {
+  input: RegisterAsOtherInputType;
+};
+
+
 export type MutationRegisterAsSupplierArgs = {
   input: RegisterAsSupplierInputType;
 };
@@ -1062,6 +1328,11 @@ export type MutationRegisterAsSupplierArgs = {
 
 export type MutationRegisterDeviceArgs = {
   input: RegisterDeviceInputType;
+};
+
+
+export type MutationRequestAcademyCourseAssetUploadArgs = {
+  input: RequestAcademyCourseAssetUploadInput;
 };
 
 
@@ -1134,6 +1405,13 @@ export type MutationSubmitSurveyResponseArgs = {
 
 export type MutationUnregisterDeviceArgs = {
   token: Scalars['String']['input'];
+};
+
+
+export type MutationUpdateAcademyCourseArgs = {
+  coverPhoto?: InputMaybe<Scalars['File']['input']>;
+  id: Scalars['String']['input'];
+  input: UpdateAcademyCourseInput;
 };
 
 
@@ -1259,8 +1537,34 @@ export type MutationUploadOrganizationTemplateArgs = {
 };
 
 
+export type MutationValidateAcademyQrArgs = {
+  input: ValidateAcademyQrInput;
+};
+
+
 export type MutationValidateApplePurchaseArgs = {
   input: ValidateApplePurchaseInputType;
+};
+
+export type MyAcademyCalendarItem = {
+  __typename?: 'MyAcademyCalendarItem';
+  courseId: Scalars['String']['output'];
+  imageUrl?: Maybe<Scalars['String']['output']>;
+  isEnrolled: Scalars['Boolean']['output'];
+  location?: Maybe<Scalars['String']['output']>;
+  modality: AcademyCourseModality;
+  scheduledAt: Scalars['DateTime']['output'];
+  streamingUrl?: Maybe<Scalars['String']['output']>;
+  title: Scalars['String']['output'];
+};
+
+export type MyAcademyCourse = {
+  __typename?: 'MyAcademyCourse';
+  id: Scalars['String']['output'];
+  imageUrl?: Maybe<Scalars['String']['output']>;
+  level?: Maybe<AcademyCourseLevel>;
+  progress: Scalars['Int']['output'];
+  title: Scalars['String']['output'];
 };
 
 export type NewsAdminFilterInputType = {
@@ -1274,6 +1578,7 @@ export enum NewsEntryType {
 }
 
 export type NewsInputType = {
+  allowedOrganizationTypes?: InputMaybe<Array<OrganizationTypes>>;
   allowedRoles?: InputMaybe<Array<UserGroups>>;
   authorName?: InputMaybe<Scalars['String']['input']>;
   description: Scalars['String']['input'];
@@ -1293,6 +1598,7 @@ export type NewsListGroupedType = {
 
 export type NewsType = {
   __typename?: 'NewsType';
+  allowedOrganizationTypes?: Maybe<Array<OrganizationTypes>>;
   allowedRoles?: Maybe<Array<UserGroups>>;
   authorName?: Maybe<Scalars['String']['output']>;
   date: Scalars['String']['output'];
@@ -1453,6 +1759,7 @@ export type OrganizationType = {
   identification?: Maybe<Scalars['String']['output']>;
   isActive: Scalars['Boolean']['output'];
   lineOfBusiness: Array<OrganizationLineOfBusiness>;
+  logoUrl?: Maybe<Scalars['String']['output']>;
   logoUrlPresigned?: Maybe<Scalars['String']['output']>;
   modality: OrganizationModality;
   name: Scalars['String']['output'];
@@ -1467,6 +1774,7 @@ export enum OrganizationTypes {
   ExclusiveAgent = 'ExclusiveAgent',
   InsuranceBroker = 'InsuranceBroker',
   InsuranceCompany = 'InsuranceCompany',
+  Other = 'Other',
   Supplier = 'Supplier'
 }
 
@@ -1612,6 +1920,12 @@ export type PublicOrganizationType = BasePublicOrganizationType & {
 
 export type Query = {
   __typename?: 'Query';
+  academyCalendarItems: Array<AcademyCalendarItem>;
+  academyCourse?: Maybe<AcademyCourse>;
+  academyCourses: Array<AcademyCourseListItem>;
+  academyDashboard: AcademyDashboard;
+  academyStudent: AcademyStudentDetail;
+  academyStudents: Array<AcademyStudentSummary>;
   adminUserById?: Maybe<AdminType>;
   adminUsers: Array<AdminType>;
   allModules: Array<ModuleType>;
@@ -1631,6 +1945,9 @@ export type Query = {
   insuranceCompaniesByClinic: Array<Scalars['String']['output']>;
   moduleById?: Maybe<ModuleType>;
   modules: Array<ModuleType>;
+  myAcademyAttendanceQr: AcademyAttendanceQr;
+  myAcademyCalendarItems: Array<MyAcademyCalendarItem>;
+  myAcademyCourses: Array<MyAcademyCourse>;
   /** Get payment history for current user/organization */
   myPayments: Array<PaymentType>;
   /** Get subscription details for the current organization */
@@ -1681,6 +1998,21 @@ export type Query = {
   trackingByEventType: Array<TrackingType>;
   trackingById?: Maybe<TrackingType>;
   unreadNotificationCount: Scalars['Int']['output'];
+};
+
+
+export type QueryAcademyCourseArgs = {
+  id: Scalars['String']['input'];
+};
+
+
+export type QueryAcademyCoursesArgs = {
+  status?: InputMaybe<AcademyCourseStatus>;
+};
+
+
+export type QueryAcademyStudentArgs = {
+  id: Scalars['String']['input'];
 };
 
 
@@ -1742,6 +2074,11 @@ export type QueryModuleByIdArgs = {
 
 export type QueryModulesArgs = {
   filter?: InputMaybe<ModuleFilterInputType>;
+};
+
+
+export type QueryMyAcademyAttendanceQrArgs = {
+  courseId: Scalars['String']['input'];
 };
 
 
@@ -2041,6 +2378,14 @@ export type RegisterAsOrganizationResponseType = {
   userId: Scalars['String']['output'];
 };
 
+export type RegisterAsOtherInputType = {
+  email: Scalars['String']['input'];
+  fiscalAddress?: InputMaybe<FiscalAddressInputType>;
+  name: Scalars['String']['input'];
+  password: Scalars['String']['input'];
+  sex: Sexes;
+};
+
 export type RegisterAsSupplierInputType = {
   email: Scalars['String']['input'];
   fiscalAddress?: InputMaybe<FiscalAddressInputType>;
@@ -2062,6 +2407,13 @@ export type RegisterRequestInsuranceCompanyInputType = {
   instagramUrl?: InputMaybe<Scalars['String']['input']>;
   phone?: InputMaybe<Scalars['String']['input']>;
   subtype?: InputMaybe<InsuranceCompanySubtype>;
+};
+
+export type RequestAcademyCourseAssetUploadInput = {
+  assetType: AcademyCourseAssetType;
+  contentType: Scalars['String']['input'];
+  fileName: Scalars['String']['input'];
+  size: Scalars['Float']['input'];
 };
 
 export type SearchOrganizationFilterType = {
@@ -2471,6 +2823,20 @@ export type TrackingUserType = {
   phone?: Maybe<Scalars['String']['output']>;
 };
 
+export type UpdateAcademyCourseInput = {
+  description?: InputMaybe<Scalars['String']['input']>;
+  finalQuizQuestions?: InputMaybe<Array<AcademyQuizQuestionInput>>;
+  imageUrl?: InputMaybe<Scalars['String']['input']>;
+  level?: InputMaybe<AcademyCourseLevel>;
+  location?: InputMaybe<Scalars['String']['input']>;
+  modality?: InputMaybe<AcademyCourseModality>;
+  modules?: InputMaybe<Array<AcademyCourseModuleInput>>;
+  priceUsd?: InputMaybe<Scalars['Float']['input']>;
+  scheduledAt?: InputMaybe<Scalars['DateTime']['input']>;
+  streamingUrl?: InputMaybe<Scalars['String']['input']>;
+  title?: InputMaybe<Scalars['String']['input']>;
+};
+
 export type UpdateCalendarEventInput = {
   date?: InputMaybe<Scalars['DateTime']['input']>;
   description?: InputMaybe<Scalars['String']['input']>;
@@ -2569,8 +2935,22 @@ export type UserType = {
   group?: Maybe<UserGroups>;
   id: Scalars['ID']['output'];
   name: Scalars['String']['output'];
+  subscription?: Maybe<SubscriptionDetailsType>;
   subscriptionPlan?: Maybe<SubscriptionPlan>;
   verifiedAt?: Maybe<Scalars['DateTime']['output']>;
+};
+
+export type ValidateAcademyQrInput = {
+  courseId: Scalars['String']['input'];
+  qrPayload: Scalars['String']['input'];
+};
+
+export type ValidateAcademyQrResult = {
+  __typename?: 'ValidateAcademyQrResult';
+  message: Scalars['String']['output'];
+  studentId?: Maybe<Scalars['String']['output']>;
+  studentName?: Maybe<Scalars['String']['output']>;
+  success: Scalars['Boolean']['output'];
 };
 
 export type ValidateApplePurchaseInputType = {

--- a/src/lib/sektor-api/__generated__/types.ts
+++ b/src/lib/sektor-api/__generated__/types.ts
@@ -16,6 +16,219 @@ export type Scalars = {
   File: { input: any; output: any; }
 };
 
+export type AcademyAttendanceQr = {
+  __typename?: 'AcademyAttendanceQr';
+  courseId: Scalars['String']['output'];
+  qrPayload: Scalars['String']['output'];
+  studentId: Scalars['String']['output'];
+};
+
+export type AcademyCalendarItem = {
+  __typename?: 'AcademyCalendarItem';
+  courseId: Scalars['String']['output'];
+  imageUrl?: Maybe<Scalars['String']['output']>;
+  location?: Maybe<Scalars['String']['output']>;
+  modality: AcademyCourseModality;
+  requiresQr: Scalars['Boolean']['output'];
+  scheduledAt: Scalars['DateTime']['output'];
+  title: Scalars['String']['output'];
+};
+
+export type AcademyCourse = {
+  __typename?: 'AcademyCourse';
+  description: Scalars['String']['output'];
+  finalQuizQuestions?: Maybe<Array<AcademyQuizQuestion>>;
+  id: Scalars['String']['output'];
+  imageUrl?: Maybe<Scalars['String']['output']>;
+  level?: Maybe<AcademyCourseLevel>;
+  location?: Maybe<Scalars['String']['output']>;
+  modality?: Maybe<AcademyCourseModality>;
+  modules?: Maybe<Array<AcademyCourseModule>>;
+  priceUsd: Scalars['Float']['output'];
+  scheduledAt?: Maybe<Scalars['DateTime']['output']>;
+  status: AcademyCourseStatus;
+  streamingUrl?: Maybe<Scalars['String']['output']>;
+  title: Scalars['String']['output'];
+};
+
+export type AcademyCourseAsset = {
+  __typename?: 'AcademyCourseAsset';
+  fileUrl: Scalars['String']['output'];
+  id: Scalars['String']['output'];
+  status: AcademyCourseAssetStatus;
+  type: AcademyCourseAssetType;
+};
+
+export enum AcademyCourseAssetStatus {
+  Pending = 'Pending',
+  Uploaded = 'Uploaded'
+}
+
+export enum AcademyCourseAssetType {
+  CourseAttachment = 'CourseAttachment',
+  CourseCover = 'CourseCover',
+  CourseVideo = 'CourseVideo'
+}
+
+export type AcademyCourseAssetUpload = {
+  __typename?: 'AcademyCourseAssetUpload';
+  assetId: Scalars['String']['output'];
+  expiresAt: Scalars['DateTime']['output'];
+  fileUrl: Scalars['String']['output'];
+  signedUrl: Scalars['String']['output'];
+  status: AcademyCourseAssetStatus;
+};
+
+export enum AcademyCourseLevel {
+  Advanced = 'Advanced',
+  Basic = 'Basic',
+  Intermediate = 'Intermediate'
+}
+
+export type AcademyCourseListItem = {
+  __typename?: 'AcademyCourseListItem';
+  enrolledCount: Scalars['Int']['output'];
+  id: Scalars['String']['output'];
+  modality?: Maybe<AcademyCourseModality>;
+  priceUsd: Scalars['Float']['output'];
+  title: Scalars['String']['output'];
+};
+
+export enum AcademyCourseModality {
+  LiveStreaming = 'LiveStreaming',
+  Online = 'Online',
+  Presential = 'Presential'
+}
+
+export type AcademyCourseModule = {
+  __typename?: 'AcademyCourseModule';
+  attachmentUrls?: Maybe<Array<Scalars['String']['output']>>;
+  content?: Maybe<Scalars['String']['output']>;
+  durationSeconds?: Maybe<Scalars['Int']['output']>;
+  quizQuestions?: Maybe<Array<AcademyQuizQuestion>>;
+  title?: Maybe<Scalars['String']['output']>;
+  type: AcademyCourseModuleType;
+  videoUrl?: Maybe<Scalars['String']['output']>;
+};
+
+export type AcademyCourseModuleInput = {
+  attachmentUrls?: InputMaybe<Array<Scalars['String']['input']>>;
+  content?: InputMaybe<Scalars['String']['input']>;
+  durationSeconds?: InputMaybe<Scalars['Int']['input']>;
+  quizQuestions?: InputMaybe<Array<AcademyQuizQuestionInput>>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  type: AcademyCourseModuleType;
+  videoUrl?: InputMaybe<Scalars['String']['input']>;
+};
+
+export enum AcademyCourseModuleType {
+  Quiz = 'Quiz',
+  Text = 'Text',
+  Video = 'Video'
+}
+
+export enum AcademyCourseStatus {
+  Archived = 'Archived',
+  Draft = 'Draft',
+  Published = 'Published'
+}
+
+export type AcademyDashboard = {
+  __typename?: 'AcademyDashboard';
+  approvalRate: Scalars['Float']['output'];
+  publishedCoursesCount: Scalars['Int']['output'];
+  revenueCurrentMonthUsd: Scalars['Float']['output'];
+  revenuePreviousMonthUsd: Scalars['Float']['output'];
+  revenueTotalUsd: Scalars['Float']['output'];
+  topCourses: Array<AcademyDashboardTopCourse>;
+  uniqueStudentsCurrentMonth: Scalars['Int']['output'];
+  uniqueStudentsPreviousMonth: Scalars['Int']['output'];
+  uniqueStudentsTotal: Scalars['Int']['output'];
+};
+
+export type AcademyDashboardTopCourse = {
+  __typename?: 'AcademyDashboardTopCourse';
+  courseId: Scalars['String']['output'];
+  imageUrl?: Maybe<Scalars['String']['output']>;
+  revenueUsd: Scalars['Float']['output'];
+  studentCount: Scalars['Int']['output'];
+  title: Scalars['String']['output'];
+};
+
+export enum AcademyEnrollmentStatus {
+  Active = 'Active',
+  Approved = 'Approved',
+  Completed = 'Completed',
+  Dropped = 'Dropped'
+}
+
+export type AcademyQuizQuestion = {
+  __typename?: 'AcademyQuizQuestion';
+  correctBooleanAnswer?: Maybe<Scalars['Boolean']['output']>;
+  correctOption?: Maybe<Scalars['String']['output']>;
+  options?: Maybe<Array<Scalars['String']['output']>>;
+  title: Scalars['String']['output'];
+  type: AcademyQuizQuestionType;
+};
+
+export type AcademyQuizQuestionInput = {
+  correctBooleanAnswer?: InputMaybe<Scalars['Boolean']['input']>;
+  correctOption?: InputMaybe<Scalars['String']['input']>;
+  options?: InputMaybe<Array<Scalars['String']['input']>>;
+  title: Scalars['String']['input'];
+  type: AcademyQuizQuestionType;
+};
+
+export enum AcademyQuizQuestionType {
+  MultipleChoice = 'MultipleChoice',
+  TrueFalse = 'TrueFalse'
+}
+
+export type AcademyStudentCertificate = {
+  __typename?: 'AcademyStudentCertificate';
+  certificateCode?: Maybe<Scalars['String']['output']>;
+  certificateId?: Maybe<Scalars['String']['output']>;
+  courseId: Scalars['String']['output'];
+  courseTitle: Scalars['String']['output'];
+  downloadUrl?: Maybe<Scalars['String']['output']>;
+  score?: Maybe<Scalars['Float']['output']>;
+  shareUrl?: Maybe<Scalars['String']['output']>;
+  studentName: Scalars['String']['output'];
+  verified: Scalars['Boolean']['output'];
+};
+
+export type AcademyStudentCompletedCourse = {
+  __typename?: 'AcademyStudentCompletedCourse';
+  courseId: Scalars['String']['output'];
+  score?: Maybe<Scalars['Float']['output']>;
+  status: AcademyEnrollmentStatus;
+  title: Scalars['String']['output'];
+};
+
+export type AcademyStudentDetail = {
+  __typename?: 'AcademyStudentDetail';
+  approvedCoursesCount: Scalars['Int']['output'];
+  approvedCoursesRatio: Scalars['Float']['output'];
+  averageScore?: Maybe<Scalars['Float']['output']>;
+  certificates: Array<AcademyStudentCertificate>;
+  completedCourses: Array<AcademyStudentCompletedCourse>;
+  email: Scalars['String']['output'];
+  enrolledCoursesCount: Scalars['Int']['output'];
+  firstEnrolledAt?: Maybe<Scalars['DateTime']['output']>;
+  id: Scalars['String']['output'];
+  initials: Scalars['String']['output'];
+  name: Scalars['String']['output'];
+  studentSinceYear?: Maybe<Scalars['Int']['output']>;
+};
+
+export type AcademyStudentSummary = {
+  __typename?: 'AcademyStudentSummary';
+  approvedCoursesCount: Scalars['Int']['output'];
+  id: Scalars['String']['output'];
+  initials: Scalars['String']['output'];
+  name: Scalars['String']['output'];
+};
+
 export type AddressInputType = {
   cityId: Scalars['Int']['input'];
   countryId: Scalars['Int']['input'];
@@ -41,6 +254,7 @@ export type AdminType = {
   group?: Maybe<UserGroups>;
   id: Scalars['ID']['output'];
   name: Scalars['String']['output'];
+  subscription?: Maybe<SubscriptionDetailsType>;
   subscriptionPlan?: Maybe<SubscriptionPlan>;
   verifiedAt?: Maybe<Scalars['DateTime']['output']>;
 };
@@ -280,6 +494,10 @@ export enum ClinicOrder {
   Current = 'Current'
 }
 
+export type ConfirmAcademyCourseAssetUploadInput = {
+  assetId: Scalars['String']['input'];
+};
+
 export type ConfirmImmediateDebitInputType = {
   holderName: Scalars['String']['input'];
   otp: Scalars['String']['input'];
@@ -310,6 +528,20 @@ export type CountryType = {
   id: Scalars['Int']['output'];
   name: Scalars['String']['output'];
   states: Array<StateType>;
+};
+
+export type CreateAcademyCourseInput = {
+  description: Scalars['String']['input'];
+  finalQuizQuestions?: InputMaybe<Array<AcademyQuizQuestionInput>>;
+  imageUrl?: InputMaybe<Scalars['String']['input']>;
+  level?: InputMaybe<AcademyCourseLevel>;
+  location?: InputMaybe<Scalars['String']['input']>;
+  modality: AcademyCourseModality;
+  modules?: InputMaybe<Array<AcademyCourseModuleInput>>;
+  priceUsd: Scalars['Float']['input'];
+  scheduledAt?: InputMaybe<Scalars['DateTime']['input']>;
+  streamingUrl?: InputMaybe<Scalars['String']['input']>;
+  title: Scalars['String']['input'];
 };
 
 export type CreateCalendarEventInput = {
@@ -361,6 +593,7 @@ export type CustomerType = {
   id: Scalars['ID']['output'];
   name: Scalars['String']['output'];
   sex: Sexes;
+  subscription?: Maybe<SubscriptionDetailsType>;
   subscriptionPlan?: Maybe<SubscriptionPlan>;
   verifiedAt?: Maybe<Scalars['DateTime']['output']>;
 };
@@ -508,6 +741,11 @@ export type FiscalAddressType = {
   reference?: Maybe<Scalars['String']['output']>;
   state: StateType;
   street: Scalars['String']['output'];
+};
+
+export type GenerateAcademyAttendanceQrInput = {
+  courseId: Scalars['String']['input'];
+  studentId: Scalars['String']['input'];
 };
 
 export type HealthQuoteInputType = {
@@ -789,10 +1027,12 @@ export type Mutation = {
   changeOrganizationFeature: PublicOrganizationType;
   changeOrganizationPlan: OrganizationType;
   changeOrganizationVisibility: OrganizationType;
+  confirmAcademyCourseAssetUpload: AcademyCourseAsset;
   /** Step 2: Confirm immediate debit with OTP code. */
   confirmImmediateDebit: InitiatePaymentResultType;
   /** Confirm Pago Móvil after R4 notification evidence exists. */
   confirmMobilePayment: ConfirmMobilePaymentResultType;
+  createAcademyCourse: AcademyCourse;
   createCalendarEvent: CalendarEventType;
   createModule: ModuleType;
   createNews: NewsType;
@@ -805,6 +1045,7 @@ export type Mutation = {
   deleteOrganization: Scalars['Boolean']['output'];
   deleteSurvey: Scalars['Boolean']['output'];
   deleteTracking: Scalars['Boolean']['output'];
+  generateAcademyAttendanceQr: AcademyAttendanceQr;
   getModuleUploadUrl: UploadFileSignedUrlResponse;
   /** Process direct debit payment with optional auto-renewal. */
   initiateDirectDebit: InitiatePaymentResultType;
@@ -820,8 +1061,10 @@ export type Mutation = {
   registerAsExclusiveAgent: RegisterAsOrganizationResponseType;
   registerAsInsuranceBroker: RegisterAsOrganizationResponseType;
   registerAsInsuranceCompany: RegisterAsOrganizationResponseType;
+  registerAsOther: RegisterAsOrganizationResponseType;
   registerAsSupplier: RegisterAsOrganizationResponseType;
   registerDevice: Scalars['Boolean']['output'];
+  requestAcademyCourseAssetUpload: AcademyCourseAssetUpload;
   requestAutoQuote: AutoQuoteType;
   requestHealthQuote: HealthQuoteType;
   requestOtherQuote: OtherQuoteType;
@@ -836,6 +1079,7 @@ export type Mutation = {
   submitNews: NewsType;
   submitSurveyResponse: SurveyResponseType;
   unregisterDevice: Scalars['Boolean']['output'];
+  updateAcademyCourse: AcademyCourse;
   updateBrokerageSociety: BrokerageSocietyType;
   updateCalendarEvent: CalendarEventType;
   updateCustomer: CustomerType;
@@ -859,6 +1103,7 @@ export type Mutation = {
   updateTracking?: Maybe<TrackingType>;
   uploadOfficesTemplate: Array<UploadFileTemplateResult>;
   uploadOrganizationTemplate: Array<UploadFileTemplateResult>;
+  validateAcademyQr: ValidateAcademyQrResult;
   /** Validate an Apple In-App Purchase transaction from StoreKit 2 */
   validateApplePurchase: ApplePurchaseResultType;
 };
@@ -917,6 +1162,11 @@ export type MutationChangeOrganizationVisibilityArgs = {
 };
 
 
+export type MutationConfirmAcademyCourseAssetUploadArgs = {
+  input: ConfirmAcademyCourseAssetUploadInput;
+};
+
+
 export type MutationConfirmImmediateDebitArgs = {
   input: ConfirmImmediateDebitInputType;
 };
@@ -924,6 +1174,12 @@ export type MutationConfirmImmediateDebitArgs = {
 
 export type MutationConfirmMobilePaymentArgs = {
   input: ConfirmMobilePaymentInputType;
+};
+
+
+export type MutationCreateAcademyCourseArgs = {
+  coverPhoto?: InputMaybe<Scalars['File']['input']>;
+  input: CreateAcademyCourseInput;
 };
 
 
@@ -986,6 +1242,11 @@ export type MutationDeleteSurveyArgs = {
 
 export type MutationDeleteTrackingArgs = {
   id: Scalars['String']['input'];
+};
+
+
+export type MutationGenerateAcademyAttendanceQrArgs = {
+  input: GenerateAcademyAttendanceQrInput;
 };
 
 
@@ -1052,6 +1313,11 @@ export type MutationRegisterAsInsuranceCompanyArgs = {
 };
 
 
+export type MutationRegisterAsOtherArgs = {
+  input: RegisterAsOtherInputType;
+};
+
+
 export type MutationRegisterAsSupplierArgs = {
   input: RegisterAsSupplierInputType;
 };
@@ -1059,6 +1325,11 @@ export type MutationRegisterAsSupplierArgs = {
 
 export type MutationRegisterDeviceArgs = {
   input: RegisterDeviceInputType;
+};
+
+
+export type MutationRequestAcademyCourseAssetUploadArgs = {
+  input: RequestAcademyCourseAssetUploadInput;
 };
 
 
@@ -1131,6 +1402,13 @@ export type MutationSubmitSurveyResponseArgs = {
 
 export type MutationUnregisterDeviceArgs = {
   token: Scalars['String']['input'];
+};
+
+
+export type MutationUpdateAcademyCourseArgs = {
+  coverPhoto?: InputMaybe<Scalars['File']['input']>;
+  id: Scalars['String']['input'];
+  input: UpdateAcademyCourseInput;
 };
 
 
@@ -1256,8 +1534,34 @@ export type MutationUploadOrganizationTemplateArgs = {
 };
 
 
+export type MutationValidateAcademyQrArgs = {
+  input: ValidateAcademyQrInput;
+};
+
+
 export type MutationValidateApplePurchaseArgs = {
   input: ValidateApplePurchaseInputType;
+};
+
+export type MyAcademyCalendarItem = {
+  __typename?: 'MyAcademyCalendarItem';
+  courseId: Scalars['String']['output'];
+  imageUrl?: Maybe<Scalars['String']['output']>;
+  isEnrolled: Scalars['Boolean']['output'];
+  location?: Maybe<Scalars['String']['output']>;
+  modality: AcademyCourseModality;
+  scheduledAt: Scalars['DateTime']['output'];
+  streamingUrl?: Maybe<Scalars['String']['output']>;
+  title: Scalars['String']['output'];
+};
+
+export type MyAcademyCourse = {
+  __typename?: 'MyAcademyCourse';
+  id: Scalars['String']['output'];
+  imageUrl?: Maybe<Scalars['String']['output']>;
+  level?: Maybe<AcademyCourseLevel>;
+  progress: Scalars['Int']['output'];
+  title: Scalars['String']['output'];
 };
 
 export type NewsAdminFilterInputType = {
@@ -1271,6 +1575,7 @@ export enum NewsEntryType {
 }
 
 export type NewsInputType = {
+  allowedOrganizationTypes?: InputMaybe<Array<OrganizationTypes>>;
   allowedRoles?: InputMaybe<Array<UserGroups>>;
   authorName?: InputMaybe<Scalars['String']['input']>;
   description: Scalars['String']['input'];
@@ -1290,6 +1595,7 @@ export type NewsListGroupedType = {
 
 export type NewsType = {
   __typename?: 'NewsType';
+  allowedOrganizationTypes?: Maybe<Array<OrganizationTypes>>;
   allowedRoles?: Maybe<Array<UserGroups>>;
   authorName?: Maybe<Scalars['String']['output']>;
   date: Scalars['String']['output'];
@@ -1450,6 +1756,7 @@ export type OrganizationType = {
   identification?: Maybe<Scalars['String']['output']>;
   isActive: Scalars['Boolean']['output'];
   lineOfBusiness: Array<OrganizationLineOfBusiness>;
+  logoUrl?: Maybe<Scalars['String']['output']>;
   logoUrlPresigned?: Maybe<Scalars['String']['output']>;
   modality: OrganizationModality;
   name: Scalars['String']['output'];
@@ -1464,6 +1771,7 @@ export enum OrganizationTypes {
   ExclusiveAgent = 'ExclusiveAgent',
   InsuranceBroker = 'InsuranceBroker',
   InsuranceCompany = 'InsuranceCompany',
+  Other = 'Other',
   Supplier = 'Supplier'
 }
 
@@ -1609,6 +1917,12 @@ export type PublicOrganizationType = BasePublicOrganizationType & {
 
 export type Query = {
   __typename?: 'Query';
+  academyCalendarItems: Array<AcademyCalendarItem>;
+  academyCourse?: Maybe<AcademyCourse>;
+  academyCourses: Array<AcademyCourseListItem>;
+  academyDashboard: AcademyDashboard;
+  academyStudent: AcademyStudentDetail;
+  academyStudents: Array<AcademyStudentSummary>;
   adminUserById?: Maybe<AdminType>;
   adminUsers: Array<AdminType>;
   allModules: Array<ModuleType>;
@@ -1628,6 +1942,9 @@ export type Query = {
   insuranceCompaniesByClinic: Array<Scalars['String']['output']>;
   moduleById?: Maybe<ModuleType>;
   modules: Array<ModuleType>;
+  myAcademyAttendanceQr: AcademyAttendanceQr;
+  myAcademyCalendarItems: Array<MyAcademyCalendarItem>;
+  myAcademyCourses: Array<MyAcademyCourse>;
   /** Get payment history for current user/organization */
   myPayments: Array<PaymentType>;
   /** Get subscription details for the current organization */
@@ -1678,6 +1995,21 @@ export type Query = {
   trackingByEventType: Array<TrackingType>;
   trackingById?: Maybe<TrackingType>;
   unreadNotificationCount: Scalars['Int']['output'];
+};
+
+
+export type QueryAcademyCourseArgs = {
+  id: Scalars['String']['input'];
+};
+
+
+export type QueryAcademyCoursesArgs = {
+  status?: InputMaybe<AcademyCourseStatus>;
+};
+
+
+export type QueryAcademyStudentArgs = {
+  id: Scalars['String']['input'];
 };
 
 
@@ -1739,6 +2071,11 @@ export type QueryModuleByIdArgs = {
 
 export type QueryModulesArgs = {
   filter?: InputMaybe<ModuleFilterInputType>;
+};
+
+
+export type QueryMyAcademyAttendanceQrArgs = {
+  courseId: Scalars['String']['input'];
 };
 
 
@@ -2038,6 +2375,14 @@ export type RegisterAsOrganizationResponseType = {
   userId: Scalars['String']['output'];
 };
 
+export type RegisterAsOtherInputType = {
+  email: Scalars['String']['input'];
+  fiscalAddress?: InputMaybe<FiscalAddressInputType>;
+  name: Scalars['String']['input'];
+  password: Scalars['String']['input'];
+  sex: Sexes;
+};
+
 export type RegisterAsSupplierInputType = {
   email: Scalars['String']['input'];
   fiscalAddress?: InputMaybe<FiscalAddressInputType>;
@@ -2059,6 +2404,13 @@ export type RegisterRequestInsuranceCompanyInputType = {
   instagramUrl?: InputMaybe<Scalars['String']['input']>;
   phone?: InputMaybe<Scalars['String']['input']>;
   subtype?: InputMaybe<InsuranceCompanySubtype>;
+};
+
+export type RequestAcademyCourseAssetUploadInput = {
+  assetType: AcademyCourseAssetType;
+  contentType: Scalars['String']['input'];
+  fileName: Scalars['String']['input'];
+  size: Scalars['Float']['input'];
 };
 
 export type SearchOrganizationFilterType = {
@@ -2468,6 +2820,20 @@ export type TrackingUserType = {
   phone?: Maybe<Scalars['String']['output']>;
 };
 
+export type UpdateAcademyCourseInput = {
+  description?: InputMaybe<Scalars['String']['input']>;
+  finalQuizQuestions?: InputMaybe<Array<AcademyQuizQuestionInput>>;
+  imageUrl?: InputMaybe<Scalars['String']['input']>;
+  level?: InputMaybe<AcademyCourseLevel>;
+  location?: InputMaybe<Scalars['String']['input']>;
+  modality?: InputMaybe<AcademyCourseModality>;
+  modules?: InputMaybe<Array<AcademyCourseModuleInput>>;
+  priceUsd?: InputMaybe<Scalars['Float']['input']>;
+  scheduledAt?: InputMaybe<Scalars['DateTime']['input']>;
+  streamingUrl?: InputMaybe<Scalars['String']['input']>;
+  title?: InputMaybe<Scalars['String']['input']>;
+};
+
 export type UpdateCalendarEventInput = {
   date?: InputMaybe<Scalars['DateTime']['input']>;
   description?: InputMaybe<Scalars['String']['input']>;
@@ -2566,8 +2932,22 @@ export type UserType = {
   group?: Maybe<UserGroups>;
   id: Scalars['ID']['output'];
   name: Scalars['String']['output'];
+  subscription?: Maybe<SubscriptionDetailsType>;
   subscriptionPlan?: Maybe<SubscriptionPlan>;
   verifiedAt?: Maybe<Scalars['DateTime']['output']>;
+};
+
+export type ValidateAcademyQrInput = {
+  courseId: Scalars['String']['input'];
+  qrPayload: Scalars['String']['input'];
+};
+
+export type ValidateAcademyQrResult = {
+  __typename?: 'ValidateAcademyQrResult';
+  message: Scalars['String']['output'];
+  studentId?: Maybe<Scalars['String']['output']>;
+  studentName?: Maybe<Scalars['String']['output']>;
+  success: Scalars['Boolean']['output'];
 };
 
 export type ValidateApplePurchaseInputType = {

--- a/src/lib/sektor-api/mutations/news/create-news.ts
+++ b/src/lib/sektor-api/mutations/news/create-news.ts
@@ -16,6 +16,7 @@ export const CREATE_NEWS = gql`
       visibility
       pendingApproval
       allowedRoles
+      allowedOrganizationTypes
     }
   }
 `;

--- a/src/lib/sektor-api/mutations/news/submit-news.ts
+++ b/src/lib/sektor-api/mutations/news/submit-news.ts
@@ -16,6 +16,7 @@ export const SUBMIT_NEWS = gql`
       visibility
       pendingApproval
       allowedRoles
+      allowedOrganizationTypes
     }
   }
 `;

--- a/src/lib/sektor-api/mutations/news/update-news.ts
+++ b/src/lib/sektor-api/mutations/news/update-news.ts
@@ -16,6 +16,7 @@ export const UPDATE_NEWS = gql`
       visibility
       pendingApproval
       allowedRoles
+      allowedOrganizationTypes
     }
   }
 `;

--- a/src/lib/sektor-api/queries/news/all-news.ts
+++ b/src/lib/sektor-api/queries/news/all-news.ts
@@ -16,6 +16,7 @@ export const ALL_NEWS_QUERY = gql`
       visibility
       pendingApproval
       allowedRoles
+      allowedOrganizationTypes
     }
   }
 `;

--- a/src/lib/sektor-api/queries/news/news-by-id.ts
+++ b/src/lib/sektor-api/queries/news/news-by-id.ts
@@ -16,6 +16,7 @@ export const NEWS_BY_ID_QUERY = gql`
       visibility
       pendingApproval
       allowedRoles
+      allowedOrganizationTypes
     }
   }
 `;

--- a/src/pages/herramientas/noticias/[id].tsx
+++ b/src/pages/herramientas/noticias/[id].tsx
@@ -15,6 +15,7 @@ import {
   UserGroups,
   NewsUploadedBy,
   NewsVisibility,
+  OrganizationTypes,
   Query,
   NewsType,
 } from "@/lib/sektor-api/__generated__/types";
@@ -41,7 +42,9 @@ const EditarNoticia = () => {
   const [videoUrl, setVideoUrl] = useState("");
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
-  const [allowedRoles, setAllowedRoles] = useState<UserGroups[]>([]);
+  const [allowedOrganizationTypes, setAllowedOrganizationTypes] = useState<
+    OrganizationTypes[]
+  >([]);
 
   const { data, loading, error: queryError } = useQuery<Query>(ALL_NEWS_QUERY, {
     fetchPolicy: "network-only",
@@ -64,7 +67,9 @@ const EditarNoticia = () => {
       setDescription(quillDeltaToText(news.description));
       setVideoUrl(news.videoUrl || "");
       setPhotoPreview(news.photoUrl || null);
-      setAllowedRoles((news.allowedRoles as UserGroups[]) || []);
+      setAllowedOrganizationTypes(
+        (news.allowedOrganizationTypes as OrganizationTypes[]) || []
+      );
 
       if (news.videoUrl) {
         setMediaType("video");
@@ -120,6 +125,8 @@ const EditarNoticia = () => {
     }
 
     try {
+      const hasOrganizationTypes = allowedOrganizationTypes.length > 0;
+
       await updateNews({
         variables: {
           id: id as string,
@@ -128,7 +135,12 @@ const EditarNoticia = () => {
             description,
             type: news.type,
             videoUrl: mediaType === "video" ? videoUrl : undefined,
-            allowedRoles: allowedRoles.length > 0 ? allowedRoles : undefined,
+            allowedOrganizationTypes: hasOrganizationTypes
+              ? allowedOrganizationTypes
+              : undefined,
+            visibility: hasOrganizationTypes
+              ? NewsVisibility.RoleBased
+              : NewsVisibility.Public,
           },
           photo: mediaType === "photo" ? photo : undefined,
         },
@@ -148,6 +160,10 @@ const EditarNoticia = () => {
     }
 
     try {
+      const organizationTypes =
+        (news.allowedOrganizationTypes as OrganizationTypes[]) || [];
+      const hasOrganizationTypes = organizationTypes.length > 0;
+
       await updateNews({
         variables: {
           id: id as string,
@@ -156,9 +172,13 @@ const EditarNoticia = () => {
             description: news.description,
             type: news.type,
             videoUrl: news.videoUrl || undefined,
-            allowedRoles: (news.allowedRoles as UserGroups[]) || undefined,
+            allowedOrganizationTypes: hasOrganizationTypes
+              ? organizationTypes
+              : undefined,
             pendingApproval: false,
-            visibility: NewsVisibility.Public,
+            visibility: hasOrganizationTypes
+              ? NewsVisibility.RoleBased
+              : NewsVisibility.Public,
           },
         },
         refetchQueries: [{ query: HOME_NEWS_QUERY }, { query: ALL_NEWS_QUERY }],
@@ -377,8 +397,8 @@ const EditarNoticia = () => {
         <div className="mb-10">
           <p className="text-blue-500 text-sm mb-4">¿Quién puede ver tu noticia?</p>
           <RoleSelector
-            selectedRoles={allowedRoles as UserGroups[]}
-            onChange={setAllowedRoles}
+            selectedRoles={allowedOrganizationTypes}
+            onChange={setAllowedOrganizationTypes}
           />
         </div>
 

--- a/src/pages/herramientas/noticias/crear.tsx
+++ b/src/pages/herramientas/noticias/crear.tsx
@@ -14,6 +14,8 @@ import {
   UserGroups,
   NewsUploadedBy,
   NewsEntryType,
+  NewsVisibility,
+  OrganizationTypes,
 } from "@/lib/sektor-api/__generated__/types";
 import { CREATE_NEWS } from "@/lib/sektor-api/mutations";
 import { ALL_NEWS_QUERY, HOME_NEWS_QUERY } from "@/lib/sektor-api/queries";
@@ -36,8 +38,9 @@ const CrearNoticia = () => {
   const [videoUrl, setVideoUrl] = useState("");
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
-  const [allowedRoles, setAllowedRoles] = useState<UserGroups[]>([]);
-
+  const [allowedOrganizationTypes, setAllowedOrganizationTypes] = useState<
+    OrganizationTypes[]
+  >([]);
 
   const [createNews, { loading }] = useMutation(CREATE_NEWS);
 
@@ -70,6 +73,8 @@ const CrearNoticia = () => {
     }
 
     try {
+      const hasOrganizationTypes = allowedOrganizationTypes.length > 0;
+
       await createNews({
         variables: {
           input: {
@@ -78,7 +83,12 @@ const CrearNoticia = () => {
             type: NewsEntryType.News,
             uploadedBy: NewsUploadedBy.Sektor,
             videoUrl: mediaType === "video" ? videoUrl : undefined,
-            allowedRoles: allowedRoles.length > 0 ? allowedRoles : undefined,
+            allowedOrganizationTypes: hasOrganizationTypes
+              ? allowedOrganizationTypes
+              : undefined,
+            visibility: hasOrganizationTypes
+              ? NewsVisibility.RoleBased
+              : NewsVisibility.Public,
           },
           photo: mediaType === "photo" ? photo : undefined,
         },
@@ -243,8 +253,8 @@ const CrearNoticia = () => {
         <div className="mb-10">
           <p className="text-blue-500 text-sm mb-4">¿Quién puede ver tu noticia?</p>
           <RoleSelector
-            selectedRoles={allowedRoles}
-            onChange={setAllowedRoles}
+            selectedRoles={allowedOrganizationTypes}
+            onChange={setAllowedOrganizationTypes}
           />
         </div>
 

--- a/src/pages/herramientas/noticias/index.tsx
+++ b/src/pages/herramientas/noticias/index.tsx
@@ -17,6 +17,7 @@ import {
   NewsType,
   NewsUploadedBy,
   NewsVisibility,
+  OrganizationTypes,
 } from "@/lib/sektor-api/__generated__/types";
 import { ALL_NEWS_QUERY, HOME_NEWS_QUERY } from "@/lib/sektor-api/queries";
 import { DELETE_NEWS, UPDATE_NEWS } from "@/lib/sektor-api/mutations";
@@ -112,6 +113,10 @@ const HerramientasNoticias = () => {
 
   const handleAuthorize = async (news: NewsType) => {
     try {
+      const organizationTypes =
+        (news.allowedOrganizationTypes as OrganizationTypes[]) || [];
+      const hasOrganizationTypes = organizationTypes.length > 0;
+
       await updateNews({
         variables: {
           id: news.id,
@@ -120,9 +125,13 @@ const HerramientasNoticias = () => {
             description: news.description,
             type: news.type,
             videoUrl: news.videoUrl || undefined,
-            allowedRoles: (news.allowedRoles as UserGroups[]) || undefined,
+            allowedOrganizationTypes: hasOrganizationTypes
+              ? organizationTypes
+              : undefined,
             pendingApproval: false,
-            visibility: NewsVisibility.Public,
+            visibility: hasOrganizationTypes
+              ? NewsVisibility.RoleBased
+              : NewsVisibility.Public,
           },
         },
         refetchQueries: [{ query: HOME_NEWS_QUERY }, { query: ALL_NEWS_QUERY }],


### PR DESCRIPTION
…settings. Update NewsAdminList, RoleSelector, and related components to support allowedOrganizationTypes instead of allowedRoles. Modify GraphQL queries and mutations to include organization types, ensuring proper handling in news creation and updates. Improve user experience by reflecting these changes in the EditarNoticia and CrearNoticia pages.